### PR TITLE
Sorbet support (initial)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rspec"
 gem 'sorbet', require: false
 gem 'sorbet-runtime', require: false
 gem 'tapioca', require: false
+gem 'pry'
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "rspec"
 gem 'sorbet', require: false
 gem 'sorbet-runtime', require: false
 gem 'tapioca', require: false
-gem 'pry'
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,6 @@ gem "rspec"
 gem 'sorbet', require: false
 gem 'sorbet-runtime', require: false
 gem "rspec"
-gem 'sorbet', require: false
-gem 'sorbet-runtime', require: false
-gem 'tapioca', require: false
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gem "rspec"
 gem 'sorbet', require: false
 gem 'sorbet-runtime', require: false
 gem "rspec"
+gem 'sorbet', require: false
+gem 'sorbet-runtime', require: false
+gem 'tapioca', require: false
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,7 @@ source "https://rubygems.org"
 gem "debug", platform: :mri
 gem "rbs", "< 3.0"
 gem "rspec"
-gem 'sorbet', require: false
 gem 'sorbet-runtime', require: false
-gem "rspec"
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source "https://rubygems.org"
 gem "debug", platform: :mri
 gem "rbs", "< 3.0"
 gem "rspec"
+gem 'sorbet', require: false
+gem 'sorbet-runtime', require: false
+gem 'tapioca', require: false
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rbs", "< 3.0"
 gem "rspec"
 gem 'sorbet', require: false
 gem 'sorbet-runtime', require: false
-gem 'tapioca', require: false
+gem "rspec"
 
 gemspec
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,16 @@ That's it! Now all mocked methods are type-checked.
 
 ### raise_on_missing_types
 
-Gem `sorbet-runtime` does not load signatures for stdlib types (Integer, String, etc...) into runtime.
-Checking types for Integer, String, etc is only available through `rbs typecheck` command which uses [custom ruby binary](https://github.com/sorbet/sorbet/blob/master/docs/running-compiled-code.md).
+If a signature is described in a `.rb` file, it will be used by `sorbet-runtime` and type checking will be available.
+One of the gems that is using sorbet signatures is [ShopifyAPI](https://github.com/Shopify/shopify-api-ruby/blob/main/lib/shopify_api/auth.rb) for example.
 
-Therefore, you should consider changing `raise_on_missing_types` to `false` if you use Sorbet.
+However, many signatures are declared inside `.rbi` files, like 1) signatures for [stdlib and core types](https://github.com/sorbet/sorbet/tree/master/rbi/core) and 2) signatures for most libraries including [rails](https://github.com/chanzuckerberg/sorbet-rails/blob/master/sorbet/rbi/sorbet-typed/lib/activerecord/all/activerecord.rbi).
+Unfortunately, these types cannot be loaded into runtime at the moment.
+It's not possible to type check their mocks yet.
+
+Checking types defined in .rbi files is only available through `rbs typecheck` command which uses [custom ruby binary](https://github.com/sorbet/sorbet/blob/master/docs/running-compiled-code.md).
+
+You should consider changing `raise_on_missing_types` to `false` if you use Sorbet.
 
 ```ruby
 MockSuey.configure do |config|

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collection of tools to keep mocks in line with real objects.
 - [Installation](#installation)
 - [Typed doubles](#typed-doubles)
   - [Using with RBS](#using-with-rbs)
+  - [Using with Sorbet](#using-with-sorbet)
   - [Typed doubles limitations](#typed-doubles-limitations)
 - [Mock context](#mock-context)
 - [Auto-generated type signatures and post-run checks](#auto-generated-type-signatures-and-post-run-checks)
@@ -83,6 +84,33 @@ Typed doubles rely on the type signatures being defined. What if you don't have 
 1) Adding type signatures only for the objects being mocked. You don't even need to type check your code or cover it with types. Instead, you can rely on runtime checks made in tests for real objects and use typed doubles for mocked objects.
 
 2) Auto-generating types on-the-fly from the real call traces (see below).
+
+### Using with Sorbet
+
+To use MockSuey with Sorbet, configure it as follows:
+
+```ruby
+MockSuey.configure do |config|
+  config.type_check = :sorbet
+end
+```
+
+Make sure that `sorbet` and `sorbet-runtime` gem are present in the bundle according to the [sorbet instruction](https://sorbet.org/docs/adopting#step-1-install-dependencies).
+That's it! Now all mocked methods are type-checked.
+
+### raise_on_missing_types
+
+Gem `sorbet-runtime` does not load signatures for stdlib types (Integer, String, etc...) into runtime.
+Checking types for Integer, String, etc is only available through `rbs typecheck` command which uses [custom ruby binary](https://github.com/sorbet/sorbet/blob/master/docs/running-compiled-code.md).
+
+Therefore, you should consider changing `raise_on_missing_types` to `false` if you use Sorbet.
+
+```ruby
+MockSuey.configure do |config|
+  config.type_check = :sorbet
+  config.raise_on_missing_types = false
+end
+```
 
 ## Mock context
 
@@ -371,6 +399,7 @@ The gem is available as open source under the terms of the [MIT License](http://
 
 [the-talk]: https://evilmartians.com/events/weaving-and-seaming-mocks
 [rbs]: https://github.com/ruby/rbs
+[sorbet]: https://github.com/sorbet/sorbet
 [fixturama]: https://github.com/nepalez/fixturama
 [bogus]: https://github.com/psyho/bogus
 [compact]: https://github.com/robwold/compact

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Typed doubles rely on the type signatures being defined. What if you don't have 
 
 ### Using with Sorbet
 
-To use MockSuey with Sorbet, configure it as follows:
+To use Mock Suey with Sorbet, configure it as follows:
 
 ```ruby
 MockSuey.configure do |config|

--- a/lib/mock_suey/core.rb
+++ b/lib/mock_suey/core.rb
@@ -4,7 +4,7 @@ module MockSuey
   class Configuration
     # No freezing this const to allow third-party libraries
     # to integrate with mock_suey
-    TYPE_CHECKERS = %w[ruby]
+    TYPE_CHECKERS = %w[ruby sorbet]
 
     attr_accessor :debug,
       :logger,

--- a/lib/mock_suey/method_call.rb
+++ b/lib/mock_suey/method_call.rb
@@ -12,7 +12,8 @@ module MockSuey
     :return_value,
     :has_kwargs,
     :metadata,
-    :mocked_instance,
+    :mocked_obj,
+    :block,
     keyword_init: true
   )
     def initialize(**)

--- a/lib/mock_suey/method_call.rb
+++ b/lib/mock_suey/method_call.rb
@@ -12,6 +12,7 @@ module MockSuey
     :return_value,
     :has_kwargs,
     :metadata,
+    :mocked_instance,
     keyword_init: true
   )
     def initialize(**)

--- a/lib/mock_suey/mock_contract.rb
+++ b/lib/mock_suey/mock_contract.rb
@@ -19,7 +19,7 @@ module MockSuey
       def captured_calls_message(calls)
         calls.map do |call|
           contract.args_pattern.map.with_index do |arg, i|
-            (ANYTHING == arg) ? "_" : call.arguments[i].inspect
+            (arg == ANYTHING) ? "_" : call.arguments[i].inspect
           end.join(", ").then do |args_desc|
             "    (#{args_desc}) -> #{call.return_value.class}"
           end

--- a/lib/mock_suey/rspec/proxy_method_invoked.rb
+++ b/lib/mock_suey/rspec/proxy_method_invoked.rb
@@ -29,10 +29,11 @@ module MockSuey
         end
 
         method_call = MockSuey::MethodCall.new(
-          mocked_instance: obj,
+          mocked_obj: obj,
           receiver_class:,
           method_name:,
           arguments: args,
+          block: block,
           metadata: {example: ::RSpec.current_example}
         )
 

--- a/lib/mock_suey/rspec/proxy_method_invoked.rb
+++ b/lib/mock_suey/rspec/proxy_method_invoked.rb
@@ -29,6 +29,7 @@ module MockSuey
         end
 
         method_call = MockSuey::MethodCall.new(
+          mocked_instance: obj,
           receiver_class:,
           method_name:,
           arguments: args,

--- a/lib/mock_suey/rspec/proxy_method_invoked.rb
+++ b/lib/mock_suey/rspec/proxy_method_invoked.rb
@@ -33,7 +33,7 @@ module MockSuey
           receiver_class:,
           method_name:,
           arguments: args,
-          block: block,
+          block:,
           metadata: {example: ::RSpec.current_example}
         )
 

--- a/lib/mock_suey/sorbet_rspec.rb
+++ b/lib/mock_suey/sorbet_rspec.rb
@@ -2,12 +2,15 @@
 
 require "sorbet-runtime"
 
+error_handler = T::Configuration.instance_variable_get(:@call_validation_error_handler)
+error_handler ||= proc do |signature, opts|
+  return T::Configuration.send(:call_validation_error_handler_default, signature, opts)
+end
+
 # Let methods with sig receive double/instance_double arguments
 T::Configuration.call_validation_error_handler = lambda do |signature, opts|
   is_mocked = opts[:value].is_a?(RSpec::Mocks::Double) || opts[:value].is_a?(RSpec::Mocks::VerifyingDouble)
-  unless is_mocked
-    return T::Configuration.send(:call_validation_error_handler_default, signature, opts)
-  end
+  return error_handler.call(signature, opts) unless is_mocked
 
   # https://github.com/rspec/rspec-mocks/blob/main/lib/rspec/mocks/verifying_double.rb
   # https://github.com/rspec/rspec-mocks/blob/v3.12.3/lib/rspec/mocks/test_double.rb
@@ -20,5 +23,5 @@ T::Configuration.call_validation_error_handler = lambda do |signature, opts|
   are_related = doubled_class <= opts[:type].raw_type
   return if are_related
 
-  return T::Configuration.send(:call_validation_error_handler_default, signature, opts)
+  error_handler.call(signature, opts)
 end

--- a/lib/mock_suey/sorbet_rspec.rb
+++ b/lib/mock_suey/sorbet_rspec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+# Let methods with sig receive double/instance_double arguments
+T::Configuration.call_validation_error_handler = lambda do |signature, opts|
+  is_mocked = opts[:value].is_a?(RSpec::Mocks::Double) || opts[:value].is_a?(RSpec::Mocks::VerifyingDouble)
+  unless is_mocked
+    return T::Configuration.send(:call_validation_error_handler_default, signature, opts)
+  end
+
+  # https://github.com/rspec/rspec-mocks/blob/main/lib/rspec/mocks/verifying_double.rb
+  # https://github.com/rspec/rspec-mocks/blob/v3.12.3/lib/rspec/mocks/test_double.rb
+  doubled_class = if opts[:value].is_a? RSpec::Mocks::Double
+    doubled_class_name = opts[:value].instance_variable_get :@name
+    Kernel.const_get(doubled_class_name)
+  elsif opts[:value].is_a? RSpec::Mocks::VerifyingDouble
+    opts[:value].instance_variable_get(:@doubled_module).send(:object)
+  end
+  are_related = doubled_class <= opts[:type].raw_type
+  return if are_related
+
+  T::Configuration.call_validation_error_handler_default(signature, opts)
+end

--- a/lib/mock_suey/sorbet_rspec.rb
+++ b/lib/mock_suey/sorbet_rspec.rb
@@ -20,5 +20,5 @@ T::Configuration.call_validation_error_handler = lambda do |signature, opts|
   are_related = doubled_class <= opts[:type].raw_type
   return if are_related
 
-  T::Configuration.call_validation_error_handler_default(signature, opts)
+  return T::Configuration.send(:call_validation_error_handler_default, signature, opts)
 end

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -23,6 +23,11 @@ module MockSuey
         unbound_original_method = call_obj.receiver_class.instance_method(method_name)
         original_method_sig = T::Private::Methods.signature_for_method(unbound_original_method)
 
+        unless original_method_sig
+          raise MissingSignature, "No signature found for #{call_obj.method_desc}" if raise_on_missing
+          return
+        end
+
         T::Private::Methods::CallValidation.validate_call(
           mocked_instance,
           unbound_mocked_method,

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -44,6 +44,8 @@ module MockSuey
         end
         block = method_call.block
 
+        mocked_obj.define_singleton_method(method_name) { |*args, &block| method_call.return_value }
+
         T::Private::Methods::CallValidation.validate_call(
           mocked_obj,
           unbound_mocked_method,

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "set"
+require "pathname"
+
+require "mock_suey/ext/instance_class"
+
+module MockSuey
+  module TypeChecks
+    using Ext::InstanceClass
+
+    class Sorbet
+      def initialize(load_dirs: [])
+        @load_dirs = Array(load_dirs)
+      end
+
+      def typecheck!(call_obj, raise_on_missing: false)
+        method_name = call_obj.method_name
+        mocked_instance = call_obj.mocked_instance
+        unbound_mocked_method = mocked_instance.method(method_name).unbind
+        args = call_obj.arguments
+
+        unbound_original_method = call_obj.receiver_class.instance_method(method_name)
+        original_method_sig = T::Private::Methods.signature_for_method(unbound_original_method)
+
+        T::Private::Methods::CallValidation.validate_call(
+          mocked_instance,
+          unbound_mocked_method,
+          original_method_sig,
+          args,
+          nil
+        )
+      end
+    end
+  end
+end

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+gem "sorbet-runtime"
+require "sorbet-runtime"
 require "set"
 require "pathname"
 
+require_relative "../sorbet_rspec"
 require "mock_suey/ext/instance_class"
 
 module MockSuey
@@ -10,30 +13,43 @@ module MockSuey
     using Ext::InstanceClass
 
     class Sorbet
+      RAISE_ON_MISSING_MESSAGE = "Please, set raise_on_missing_types to false to disable this error. Details: https://github.com/test-prof/mock-suey#raise_on_missing_types"
+
       def initialize(load_dirs: [])
         @load_dirs = Array(load_dirs)
       end
 
-      def typecheck!(call_obj, raise_on_missing: false)
-        method_name = call_obj.method_name
-        mocked_instance = call_obj.mocked_instance
-        unbound_mocked_method = mocked_instance.method(method_name).unbind
-        args = call_obj.arguments
+      def typecheck!(method_call, raise_on_missing: false)
+        method_name = method_call.method_name
+        mocked_obj = method_call.mocked_obj
+        is_singleton = method_call.receiver_class.singleton_class?
+        is_a_class = mocked_obj.is_a? Class
+        unbound_mocked_method = if is_singleton
+          mocked_obj.instance_method(method_name)
+        else
+          mocked_obj.method(method_name).unbind
+        end
+        args = method_call.arguments
 
-        unbound_original_method = call_obj.receiver_class.instance_method(method_name)
+        unbound_original_method = if is_a_class
+          mocked_obj.method(method_name)
+        else
+          method_call.receiver_class.instance_method(method_name)
+        end
         original_method_sig = T::Private::Methods.signature_for_method(unbound_original_method)
 
         unless original_method_sig
-          raise MissingSignature, "No signature found for #{call_obj.method_desc}" if raise_on_missing
+          raise MissingSignature, RAISE_ON_MISSING_MESSAGE if raise_on_missing
           return
         end
+        block = method_call.block
 
         T::Private::Methods::CallValidation.validate_call(
-          mocked_instance,
+          mocked_obj,
           unbound_mocked_method,
           original_method_sig,
           args,
-          nil
+          block
         )
       end
     end

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -36,7 +36,7 @@ module MockSuey
         else
           method_call.receiver_class.instance_method(method_name)
         end
-        original_method_sig = T::Private::Methods.signature_for_method(unbound_original_method)
+        original_method_sig = T::Utils.signature_for_method(unbound_original_method)
 
         unless original_method_sig
           raise MissingSignature, RAISE_ON_MISSING_MESSAGE if raise_on_missing

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -20,39 +20,71 @@ module MockSuey
       end
 
       def typecheck!(method_call, raise_on_missing: false)
+        original_method_sig = get_original_method_sig(method_call)
+        return sig_is_missing(raise_on_missing) unless original_method_sig
+
+        unbound_mocked_method = get_unbound_mocked_method(method_call)
+        override_mocked_method_to_avoid_recursion(method_call)
+
+        validate_call!(
+          instance: method_call.mocked_obj,
+          original_method: unbound_mocked_method,
+          method_sig: original_method_sig,
+          args: method_call.arguments,
+          blk: method_call.block
+        )
+      end
+
+      private
+
+      def validate_call!(instance:, original_method:, method_sig:, args:, blk:)
+        T::Private::Methods::CallValidation.validate_call(
+          instance,
+          original_method,
+          method_sig,
+          args,
+          blk
+        )
+      end
+
+      def get_unbound_mocked_method(method_call)
         method_name = method_call.method_name
         mocked_obj = method_call.mocked_obj
+
         is_singleton = method_call.receiver_class.singleton_class?
-        is_a_class = mocked_obj.is_a? Class
-        unbound_mocked_method = if is_singleton
+        if is_singleton
           mocked_obj.instance_method(method_name)
         else
           mocked_obj.method(method_name).unbind
         end
-        args = method_call.arguments
+      end
 
-        unbound_original_method = if is_a_class
-          mocked_obj.method(method_name)
+      def get_original_method_sig(method_call)
+        unbound_original_method = get_unbound_original_method(method_call)
+        T::Utils.signature_for_method(unbound_original_method)
+      end
+
+      def get_unbound_original_method(method_call)
+        method_name = method_call.method_name
+        mocked_obj = method_call.mocked_obj
+        is_a_class = mocked_obj.is_a? Class
+
+        if is_a_class
+          method_call.mocked_obj.method(method_name)
         else
           method_call.receiver_class.instance_method(method_name)
         end
-        original_method_sig = T::Utils.signature_for_method(unbound_original_method)
+      end
 
-        unless original_method_sig
-          raise MissingSignature, RAISE_ON_MISSING_MESSAGE if raise_on_missing
-          return
-        end
-        block = method_call.block
+      def sig_is_missing(raise_on_missing)
+        raise MissingSignature, RAISE_ON_MISSING_MESSAGE if raise_on_missing
+      end
 
-        mocked_obj.define_singleton_method(method_name) { |*args, &block| method_call.return_value }
-
-        T::Private::Methods::CallValidation.validate_call(
-          mocked_obj,
-          unbound_mocked_method,
-          original_method_sig,
-          args,
-          block
-        )
+      def override_mocked_method_to_avoid_recursion(method_call)
+        method_name = method_call.method_name
+        mocked_obj = method_call.mocked_obj
+        return_value = method_call.return_value
+        mocked_obj.define_singleton_method(method_name) { |*args, &block| return_value }
       end
     end
   end

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -48,15 +48,7 @@ module MockSuey
       end
 
       def get_unbound_mocked_method(method_call)
-        method_name = method_call.method_name
-        mocked_obj = method_call.mocked_obj
-
-        is_singleton = method_call.receiver_class.singleton_class?
-        if is_singleton
-          mocked_obj.instance_method(method_name)
-        else
-          mocked_obj.method(method_name).unbind
-        end
+        method_call.mocked_obj.method(method_call.method_name).unbind
       end
 
       def get_original_method_sig(method_call)

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "sorbet-runtime"
+gem "sorbet-runtime", "~> 0.5"
 require "sorbet-runtime"
 require "set"
 require "pathname"

--- a/lib/mock_suey/type_checks/sorbet.rb
+++ b/lib/mock_suey/type_checks/sorbet.rb
@@ -5,7 +5,7 @@ require "sorbet-runtime"
 require "set"
 require "pathname"
 
-require_relative "../sorbet_rspec"
+require "mock_suey/sorbet_rspec"
 require "mock_suey/ext/instance_class"
 
 module MockSuey

--- a/spec/cases/typed_double_sorbet_spec.rb
+++ b/spec/cases/typed_double_sorbet_spec.rb
@@ -17,7 +17,7 @@ describe "Typed double extension" do
           status, output = run_rspec("instance_double_sorbet", env: env)
 
           expect(status).not_to be_success
-          expect(output).to include("5 examples, 3 failures")
+          expect(output).to include("6 examples, 3 failures")
           expect(output).to include("AccountantSorbet #tax_rate_for")
           expect(output).to include("AccountantSorbet #net_pay")
           expect(output).to include("AccountantSorbet#tax_for negative amount")

--- a/spec/cases/typed_double_sorbet_spec.rb
+++ b/spec/cases/typed_double_sorbet_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe "Typed double extension" do
+  context "RSpec" do
+    let(:env) { {"TYPED_SORBET" => "true"} }
+
+    it "has no affect on simple double" do
+      status, output = run_rspec("double_sorbet", env: env)
+
+      expect(status).to be_success
+      expect(output).to include("6 examples, 0 failures")
+    end
+
+    context "instance_double" do
+      context "when signatures exist" do
+        it "enhances instance_double without extensions" do
+          status, output = run_rspec("instance_double_sorbet", env: env)
+
+          expect(status).not_to be_success
+          expect(output).to include("5 examples, 3 failures")
+          expect(output).to include("AccountantSorbet #tax_rate_for")
+          expect(output).to include("AccountantSorbet #net_pay")
+          expect(output).to include("AccountantSorbet#tax_for negative amount")
+        end
+      end
+
+      context "when signatures do not exist" do
+        it "behaves as regular instance_double" do
+          status, output = run_rspec("instance_double", env: env)
+
+          expect(status).not_to be_success
+          expect(output).to include("5 examples, 1 failure")
+        end
+      end
+    end
+  end
+end

--- a/spec/cases/typed_double_sorbet_spec.rb
+++ b/spec/cases/typed_double_sorbet_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Typed double extension" do
+describe "Sorbet integration tests" do
   context "RSpec" do
     let(:env) { {"TYPED_SORBET" => "true"} }
 
@@ -11,26 +11,16 @@ describe "Typed double extension" do
       expect(output).to include("6 examples, 0 failures")
     end
 
-    context "instance_double" do
-      context "when signatures exist" do
-        it "enhances instance_double without extensions" do
-          status, output = run_rspec("instance_double_sorbet", env: env)
+    context "instance_double_sorbet" do
+      it "enhances instance_double without extensions" do
+        status, output = run_rspec("instance_double_sorbet", env: env)
 
-          expect(status).not_to be_success
-          expect(output).to include("6 examples, 3 failures")
-          expect(output).to include("AccountantSorbet #tax_rate_for")
-          expect(output).to include("AccountantSorbet #net_pay")
-          expect(output).to include("AccountantSorbet#tax_for negative amount")
-        end
-      end
-
-      context "when signatures do not exist" do
-        it "behaves as regular instance_double" do
-          status, output = run_rspec("instance_double", env: env)
-
-          expect(status).not_to be_success
-          expect(output).to include("5 examples, 1 failure")
-        end
+        expect(status).not_to be_success
+        expect(output).to include("16 examples")
+        expect(output).to include("5 failures")
+        expect(output).to include("AccountantSorbet#tax_rate_for")
+        expect(output).to include("AccountantSorbet#net_pay")
+        expect(output).to include("AccountantSorbet#tax_for")
       end
     end
   end

--- a/spec/fixtures/rspec/double_fixture.rb
+++ b/spec/fixtures/rspec/double_fixture.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "mock_suey/type_checks/ruby"
 $LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
 
 require_relative "./spec_helper"

--- a/spec/fixtures/rspec/double_fixture.rb
+++ b/spec/fixtures/rspec/double_fixture.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "mock_suey/type_checks/ruby"
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
-
 require_relative "./spec_helper"
 require_relative "../shared/tax_calculator"
 require_relative "tax_calculator_spec"

--- a/spec/fixtures/rspec/double_sorbet_fixture.rb
+++ b/spec/fixtures/rspec/double_sorbet_fixture.rb
@@ -4,12 +4,12 @@ $LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
 
 require_relative "./spec_helper"
 require_relative "../shared/tax_calculator_sorbet"
-require_relative "tax_calculator_spec"
+require_relative "tax_calculator_sorbet_spec"
 
 describe AccountantSorbet do
   before do
     allow(tax_calculator).to receive(:for_income).and_return(42)
-    allow(tax_calculator).to receive(:tax_rate_for).and_return(10)
+    allow(tax_calculator).to receive(:tax_rate_for).and_return(10.0)
     allow(tax_calculator).to receive(:for_income).with(-10).and_return(TaxCalculator::Result.new(0))
   end
 

--- a/spec/fixtures/rspec/double_sorbet_fixture.rb
+++ b/spec/fixtures/rspec/double_sorbet_fixture.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+
+require_relative "./spec_helper"
+require_relative "../shared/tax_calculator_sorbet"
+require_relative "tax_calculator_spec"
+
+describe AccountantSorbet do
+  before do
+    allow(tax_calculator).to receive(:for_income).and_return(42)
+    allow(tax_calculator).to receive(:tax_rate_for).and_return(10)
+    allow(tax_calculator).to receive(:for_income).with(-10).and_return(TaxCalculator::Result.new(0))
+  end
+
+  let(:tax_calculator) { double("TaxCalculatorSorbet") }
+
+  include_examples "accountant", AccountantSorbet do
+    it "incorrect" do
+      # NOTE: in fact, sorbet-runtine also checks for type errors for ALL types
+      expect { subject.net_pay("incorrect") }.to raise_error(TypeError)
+    end
+  end
+end

--- a/spec/fixtures/rspec/double_sorbet_fixture.rb
+++ b/spec/fixtures/rspec/double_sorbet_fixture.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
-
 require_relative "./spec_helper"
 require_relative "../shared/tax_calculator_sorbet"
 require_relative "tax_calculator_sorbet_spec"

--- a/spec/fixtures/rspec/instance_double_fixture.rb
+++ b/spec/fixtures/rspec/instance_double_fixture.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "mock_suey/type_checks/ruby"
 $LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
 
 require_relative "./spec_helper"

--- a/spec/fixtures/rspec/instance_double_fixture.rb
+++ b/spec/fixtures/rspec/instance_double_fixture.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "mock_suey/type_checks/ruby"
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
-
 require_relative "./spec_helper"
 require_relative "../shared/tax_calculator"
 require_relative "tax_calculator_spec"

--- a/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
+++ b/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
@@ -4,40 +4,126 @@ $LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
 
 require_relative "./spec_helper"
 require_relative "../shared/tax_calculator_sorbet"
-require_relative "tax_calculator_spec"
+require_relative "tax_calculator_sorbet_spec"
 
 describe AccountantSorbet do
-  let!(:tax_calculator) {
-    target = instance_double("TaxCalculatorSorbet")
-    allow(target).to receive(:tax_rate_for).and_return(10)
-    # FAILURE(typed): Return type is incorrect
-    allow(target).to receive(:for_income).and_return(42)
-    # FAILURE(contract): Return type doesn't match the passed arguments
-    allow(target).to receive(:for_income).with(-10).and_return(TaxCalculator::Result.new(0))
-    target
-  }
+  let!(:tax_calculator) { instance_double("TaxCalculatorSorbet") }
   let!(:accountant) { AccountantSorbet.new(tax_calculator: tax_calculator) }
 
-  it "sorbet_rspec" do
-    unrelated_double = instance_double("Array")
-    expect do
-      described_class.new(tax_calculator: unrelated_double)
-    end.to raise_error(TypeError, /.*Expected type TaxCalculator, got type RSpec::Mocks::InstanceVerifyingDouble.*/)
+  describe ".initialize checks handled by sorbet_rspec.rb" do
+    it "correct param" do
+      tc = TaxCalculatorSorbet.new
+      expect { described_class.new(tax_calculator: tc) }.not_to raise_error
+    end
+    it "correct double" do
+      tc = double("TaxCalculatorSorbet")
+      expect { described_class.new(tax_calculator: tc) }.not_to raise_error
+    end
+    it "correct instance double" do
+      tc = instance_double("TaxCalculatorSorbet")
+      expect { described_class.new(tax_calculator: tc) }.not_to raise_error
+    end
+    it "correct instance double from parent class" do
+      tc = instance_double("TaxCalculator")
+      expect { described_class.new(tax_calculator: tc) }.not_to raise_error
+    end
+    it "unrelated double" do
+      unrelated_double = instance_double("Array")
+      expect do
+        described_class.new(tax_calculator: unrelated_double)
+      end.to raise_error(TypeError, /.*Expected type TaxCalculator, got type RSpec::Mocks::InstanceVerifyingDouble.*/)
+    end
   end
 
-  it "#net_pay" do
-    expect(subject.net_pay(89)).to eq 47
+  describe "#net_pay" do
+    describe "without mocks" do
+      let(:tax_calculator) { TaxCalculatorSorbet.new }
+      it "raises ruby error because the method is intentionally written incorrectly" do
+        expect { accountant.net_pay(10) }.to raise_error(TypeError, "TaxCalculator::Result can't be coerced into Integer")
+        expect { accountant.net_pay(10) }.not_to raise_error # intentionaly
+      end
+    end
+
+    describe "with mocks" do
+      let!(:tax_calculator) do
+        target = instance_double("TaxCalculatorSorbet")
+        allow(target).to receive(:for_income).and_return(return_result)
+        target
+      end
+      describe "with incorrect return" do
+        let(:return_result) { Array }
+        it "raises error because the method is intentionally written incorrectly" do
+          expect { accountant.net_pay(10) }.to raise_error(TypeError)
+          expect { accountant.net_pay(10) }.not_to raise_error # intentionaly
+        end
+      end
+      describe "with correct return" do
+        let!(:return_result) { TaxCalculator::Result.new(3, 33) }
+        it "raises error because the method is intentionally written incorrectly" do
+          expect { accountant.net_pay(10) }.to raise_error(TypeError)
+          expect { accountant.net_pay(10) }.not_to raise_error # intentionaly
+        end
+      end
+    end
   end
 
-  it "#tax_rate_for" do
-    # FAILURE(verified): Result in TaxCalucalor.tax_rate_for(40) calls,
-    # which doesn't match the parameters
-    expect(subject.tax_rate_for(40)).to eq(10)
+  describe "#tax_rate_for" do
+    describe "without mocks" do
+      let(:tax_calculator) { TaxCalculatorSorbet.new }
+      it "succeeds" do
+        expect { accountant.tax_rate_for(10) }.not_to raise_error
+      end
+    end
+
+    describe "with mocks" do
+      let!(:tax_calculator) do
+        target = TaxCalculatorSorbet.new
+        allow(target).to receive(:tax_rate_for).and_return(return_result)
+        target
+      end
+      describe "with incorrect return" do
+        let(:return_result) { "incorrect" }
+        it "fails with TypeError" do
+          expect { accountant.tax_rate_for(10) }.to raise_error(TypeError, /.*Return value.*Expected type Float, got type String.*/)
+          expect { accountant.tax_rate_for(10) }.not_to raise_error # intentionaly
+        end
+      end
+      describe "with correct return" do
+        let(:return_result) { 0.333 }
+        it "returns correct result" do
+          expect(accountant.tax_rate_for(10)).to eq(0.333)
+        end
+      end
+    end
   end
 
   describe "#tax_for" do
-    specify "negative amount" do
-      expect(subject.tax_for(-10)).to eq(0)
+    describe "without mocks" do
+      let(:tax_calculator) { TaxCalculatorSorbet.new }
+      it "succeeds" do
+        expect { accountant.tax_for(10) }.not_to raise_error
+      end
+    end
+
+    describe "with mocks" do
+      let!(:tax_calculator) do
+        target = TaxCalculatorSorbet.new
+        allow(target).to receive(:tax_rate_for).and_return(return_result)
+        target
+      end
+      describe "with incorrect return" do
+        let(:return_result) { Array }
+        it "fails with NoMethodError because tax_rate_for does not have signature" do
+          expect { accountant.tax_for(10) }.to raise_error(NoMethodError)
+          expect { accountant.tax_for(10) }.not_to raise_error # intentionaly
+        end
+      end
+      describe "with correct return" do
+        let(:return_result) { 0.333 }
+        it "returns correct result" do
+          expect(accountant.tax_for(10)).to eq(3)
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
+++ b/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
+
+require_relative "./spec_helper"
+require_relative "../shared/tax_calculator_sorbet"
+require_relative "tax_calculator_spec"
+
+describe AccountantSorbet do
+  let!(:tax_calculator) {
+    target = instance_double("TaxCalculatorSorbet")
+    allow(target).to receive(:tax_rate_for).and_return(10)
+    # FAILURE(typed): Return type is incorrect
+    allow(target).to receive(:for_income).and_return(42)
+    # FAILURE(contract): Return type doesn't match the passed arguments
+    allow(target).to receive(:for_income).with(-10).and_return(TaxCalculator::Result.new(0))
+    target
+  }
+  let!(:accountant) { AccountantSorbet.new(tax_calculator: tax_calculator) }
+
+  it "#net_pay" do
+    expect(subject.net_pay(89)).to eq 47
+  end
+
+  it "#tax_rate_for" do
+    # FAILURE(verified): Result in TaxCalucalor.tax_rate_for(40) calls,
+    # which doesn't match the parameters
+    expect(subject.tax_rate_for(40)).to eq(10)
+  end
+
+  describe "#tax_for" do
+    specify "negative amount" do
+      expect(subject.tax_for(-10)).to eq(0)
+    end
+  end
+end

--- a/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
+++ b/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
@@ -18,6 +18,13 @@ describe AccountantSorbet do
   }
   let!(:accountant) { AccountantSorbet.new(tax_calculator: tax_calculator) }
 
+  it "sorbet_rspec" do
+    unrelated_double = instance_double("Array")
+    expect do
+      described_class.new(tax_calculator: unrelated_double)
+    end.to raise_error(TypeError, /.*Expected type TaxCalculator, got type RSpec::Mocks::InstanceVerifyingDouble.*/)
+  end
+
   it "#net_pay" do
     expect(subject.net_pay(89)).to eq 47
   end

--- a/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
+++ b/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
-
 require_relative "./spec_helper"
 require_relative "../shared/tax_calculator_sorbet"
 require_relative "tax_calculator_sorbet_spec"

--- a/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
+++ b/spec/fixtures/rspec/instance_double_sorbet_fixture.rb
@@ -38,6 +38,7 @@ describe AccountantSorbet do
   describe "#net_pay" do
     describe "without mocks" do
       let(:tax_calculator) { TaxCalculatorSorbet.new }
+
       it "raises ruby error because the method is intentionally written incorrectly" do
         expect { accountant.net_pay(10) }.to raise_error(TypeError, "TaxCalculator::Result can't be coerced into Integer")
         expect { accountant.net_pay(10) }.not_to raise_error # intentionaly
@@ -50,15 +51,19 @@ describe AccountantSorbet do
         allow(target).to receive(:for_income).and_return(return_result)
         target
       end
+
       describe "with incorrect return" do
         let(:return_result) { Array }
+
         it "raises error because the method is intentionally written incorrectly" do
           expect { accountant.net_pay(10) }.to raise_error(TypeError)
           expect { accountant.net_pay(10) }.not_to raise_error # intentionaly
         end
       end
+
       describe "with correct return" do
         let!(:return_result) { TaxCalculator::Result.new(3, 33) }
+
         it "raises error because the method is intentionally written incorrectly" do
           expect { accountant.net_pay(10) }.to raise_error(TypeError)
           expect { accountant.net_pay(10) }.not_to raise_error # intentionaly
@@ -70,6 +75,7 @@ describe AccountantSorbet do
   describe "#tax_rate_for" do
     describe "without mocks" do
       let(:tax_calculator) { TaxCalculatorSorbet.new }
+
       it "succeeds" do
         expect { accountant.tax_rate_for(10) }.not_to raise_error
       end
@@ -81,15 +87,19 @@ describe AccountantSorbet do
         allow(target).to receive(:tax_rate_for).and_return(return_result)
         target
       end
+
       describe "with incorrect return" do
         let(:return_result) { "incorrect" }
+
         it "fails with TypeError" do
           expect { accountant.tax_rate_for(10) }.to raise_error(TypeError, /.*Return value.*Expected type Float, got type String.*/)
           expect { accountant.tax_rate_for(10) }.not_to raise_error # intentionaly
         end
       end
+
       describe "with correct return" do
         let(:return_result) { 0.333 }
+
         it "returns correct result" do
           expect(accountant.tax_rate_for(10)).to eq(0.333)
         end
@@ -100,6 +110,7 @@ describe AccountantSorbet do
   describe "#tax_for" do
     describe "without mocks" do
       let(:tax_calculator) { TaxCalculatorSorbet.new }
+
       it "succeeds" do
         expect { accountant.tax_for(10) }.not_to raise_error
       end
@@ -111,15 +122,19 @@ describe AccountantSorbet do
         allow(target).to receive(:tax_rate_for).and_return(return_result)
         target
       end
+
       describe "with incorrect return" do
         let(:return_result) { Array }
+
         it "fails with NoMethodError because tax_rate_for does not have signature" do
           expect { accountant.tax_for(10) }.to raise_error(NoMethodError)
           expect { accountant.tax_for(10) }.not_to raise_error # intentionaly
         end
       end
+
       describe "with correct return" do
         let(:return_result) { 0.333 }
+
         it "returns correct result" do
           expect(accountant.tax_for(10)).to eq(3)
         end

--- a/spec/fixtures/rspec/mock_context_fixture.rb
+++ b/spec/fixtures/rspec/mock_context_fixture.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "mock_suey/type_checks/ruby"
 $LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
 
 require_relative "./spec_helper"

--- a/spec/fixtures/rspec/mock_context_fixture.rb
+++ b/spec/fixtures/rspec/mock_context_fixture.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "mock_suey/type_checks/ruby"
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
-
 require_relative "./spec_helper"
 require_relative "../shared/tax_calculator"
 require_relative "tax_calculator_spec"

--- a/spec/fixtures/rspec/shared_examples/account_examples.rb
+++ b/spec/fixtures/rspec/shared_examples/account_examples.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-shared_examples "accountant" do
-  subject { Accountant.new(tax_calculator: tax_calculator) }
+shared_examples "accountant" do |class_name = Accountant|
+  subject { class_name.new(tax_calculator: tax_calculator) }
 
   it "#net_pay" do
     expect(subject.net_pay(89)).to eq 47

--- a/spec/fixtures/rspec/spec_helper.rb
+++ b/spec/fixtures/rspec/spec_helper.rb
@@ -6,6 +6,7 @@ MockSuey.configure do |config|
   config.debug = true
   config.store_mocked_calls = ENV["STORE_MOCKS"] == "true"
   config.type_check = :ruby if ENV["TYPED_DOUBLE"] == "true"
+  config.type_check = :sorbet if ENV["TYPED_SORBET"] == "true"
   config.signature_load_dirs = ENV["RBS_SIG_PATH"]
   config.auto_type_check = ENV["AUTO_TYPE_CHECK"] == "true"
   config.verify_mock_contracts = ENV["VERIFY_CONTRACTS"] == "true"

--- a/spec/fixtures/rspec/stored_mocked_calls_fixture.rb
+++ b/spec/fixtures/rspec/stored_mocked_calls_fixture.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../../../lib", __FILE__)
-
 require_relative "./spec_helper"
 require_relative "../shared/tax_calculator"
 

--- a/spec/fixtures/rspec/tax_calculator_sorbet_spec.rb
+++ b/spec/fixtures/rspec/tax_calculator_sorbet_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../shared/tax_calculator_sorbet"
+
+describe TaxCalculatorSorbet do
+  subject { described_class.new }
+
+  describe "#for_income" do
+    specify "positive" do
+      expect(subject.for_income(89).result).to eq(19)
+    end
+
+    specify "negative" do
+      expect(subject.for_income(-10)).to be_nil
+    end
+  end
+end

--- a/spec/fixtures/shared/tax_calculator_sorbet.rb
+++ b/spec/fixtures/shared/tax_calculator_sorbet.rb
@@ -6,7 +6,7 @@ require_relative "./tax_calculator"
 class TaxCalculatorSorbet < TaxCalculator
   extend T::Sig
 
-  sig { params(val: Integer).returns(Result) }
+  sig { params(val: Integer).returns(T.nilable(Result)) }
   def for_income(val)
     return if val < 0
 
@@ -59,6 +59,7 @@ class AccountantSorbet < Accountant
 
   sig { params(val: Integer).returns(Integer) }
   def net_pay(val)
+    # intentionally incorrect
     val - tax_calculator.for_income(val)
   end
 
@@ -67,7 +68,7 @@ class AccountantSorbet < Accountant
     tax_calculator.for_income(val).result
   end
 
-  sig { params(value: Integer).returns(Integer) }
+  sig { params(value: Integer).returns(Float) }
   def tax_rate_for(value)
     tax_calculator.tax_rate_for(value:)
   end

--- a/spec/fixtures/shared/tax_calculator_sorbet.rb
+++ b/spec/fixtures/shared/tax_calculator_sorbet.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require_relative "./tax_calculator"
+
+class TaxCalculatorSorbet < TaxCalculator
+  extend T::Sig
+
+  sig { params(val: Integer).returns(Integer) }
+  def simple_test(val)
+    val
+  end
+end

--- a/spec/fixtures/shared/tax_calculator_sorbet.rb
+++ b/spec/fixtures/shared/tax_calculator_sorbet.rb
@@ -10,4 +10,8 @@ class TaxCalculatorSorbet < TaxCalculator
   def simple_test(val)
     val
   end
+
+  def simple_test_no_sig(val)
+    val
+  end
 end

--- a/spec/fixtures/shared/tax_calculator_sorbet.rb
+++ b/spec/fixtures/shared/tax_calculator_sorbet.rb
@@ -6,6 +6,37 @@ require_relative "./tax_calculator"
 class TaxCalculatorSorbet < TaxCalculator
   extend T::Sig
 
+  sig { params(val: Integer).returns(Result) }
+  def for_income(val)
+    return if val < 0
+
+    tax_rate = tax_rate_for(value: val)
+
+    Result.new((tax_rate * val).to_i, tax_rate)
+  end
+
+  def tax_rate_for(value:)
+    self.class.tax_rate_for(value: value)
+  end
+
+  def self.tax_rate_for(value:)
+    TAX_BRACKETS.keys.find { _1 > value }.then { TAX_BRACKETS[_1] }
+  end
+
+  sig { params(val: Integer).returns(Integer) }
+  def self.class_method_test(val)
+    val
+  end
+
+  def self.class_method_test_no_sig(val)
+    val
+  end
+
+  sig { params(val: Integer, blk: T.proc.params(a: Integer).returns(String)).returns(String) }
+  def simple_block(val, &blk)
+    blk.call(val)
+  end
+
   sig { params(val: Integer).returns(Integer) }
   def simple_test(val)
     val
@@ -13,5 +44,31 @@ class TaxCalculatorSorbet < TaxCalculator
 
   def simple_test_no_sig(val)
     val
+  end
+end
+
+class AccountantSorbet < Accountant
+  extend T::Sig
+
+  attr_reader :tax_calculator
+
+  sig { params(tax_calculator: TaxCalculator).void }
+  def initialize(tax_calculator: TaxCalculator.new)
+    @tax_calculator = tax_calculator
+  end
+
+  sig { params(val: Integer).returns(Integer) }
+  def net_pay(val)
+    val - tax_calculator.for_income(val)
+  end
+
+  sig { params(val: Integer).returns(Integer) }
+  def tax_for(val)
+    tax_calculator.for_income(val).result
+  end
+
+  sig { params(value: Integer).returns(Integer) }
+  def tax_rate_for(value)
+    tax_calculator.tax_rate_for(value:)
   end
 end

--- a/spec/fixtures/shared/tax_calculator_sorbet.rb
+++ b/spec/fixtures/shared/tax_calculator_sorbet.rb
@@ -51,6 +51,11 @@ class TaxCalculatorSorbet < TaxCalculator
     val
   end
 
+  sig { params(val: Integer).returns(Integer).on_failure(:log) }
+  def simple_test_log_on_error(val)
+    val
+  end
+
   class << self
     extend T::Sig
 

--- a/spec/fixtures/shared/tax_calculator_sorbet.rb
+++ b/spec/fixtures/shared/tax_calculator_sorbet.rb
@@ -46,6 +46,11 @@ class TaxCalculatorSorbet < TaxCalculator
     val
   end
 
+  T::Sig::WithoutRuntime.sig { params(val: Integer).returns(Integer) }
+  def simple_test_no_runtime(val)
+    val
+  end
+
   class << self
     extend T::Sig
 

--- a/spec/fixtures/shared/tax_calculator_sorbet.rb
+++ b/spec/fixtures/shared/tax_calculator_sorbet.rb
@@ -45,6 +45,15 @@ class TaxCalculatorSorbet < TaxCalculator
   def simple_test_no_sig(val)
     val
   end
+
+  class << self
+    extend T::Sig
+
+    sig { params(val: Integer).returns(Integer) }
+    def self.singleton_test(val)
+      val
+    end
+  end
 end
 
 class AccountantSorbet < Accountant

--- a/spec/rspec/proxy_method_invoked_hook_spec.rb
+++ b/spec/rspec/proxy_method_invoked_hook_spec.rb
@@ -38,7 +38,7 @@ describe "#proxy_method_invoked" do
       method_name: :key?,
       arguments: ["x"],
       return_value: true,
-      mocked_instance: target
+      mocked_obj: target
     )
   end
 
@@ -54,7 +54,24 @@ describe "#proxy_method_invoked" do
       method_name: :key?,
       arguments: ["x"],
       return_value: true,
-      mocked_instance: target
+      mocked_obj: target
+    )
+  end
+
+  it "#instance_double with block" do
+    target = instance_double(TestHash)
+    allow(target).to receive(:each_key).and_yield("444")
+
+    block = proc { |_| "333" }
+    expect(target.each_key { |n| n }).to eq("444")
+
+    expect(mcalls.size).to eq(1)
+    expect(mcalls.first).to have_attributes(
+      receiver_class: TestHash,
+      method_name: :each_key,
+      arguments: [],
+      mocked_obj: target,
+      block: block
     )
   end
 
@@ -70,7 +87,7 @@ describe "#proxy_method_invoked" do
       method_name: :key?,
       arguments: ["x"],
       return_value: true,
-      mocked_instance: target
+      mocked_obj: target
     )
   end
 
@@ -86,7 +103,7 @@ describe "#proxy_method_invoked" do
       method_name: :key?,
       arguments: ["x"],
       return_value: true,
-      mocked_instance: target
+      mocked_obj: target
     )
   end
 
@@ -100,7 +117,7 @@ describe "#proxy_method_invoked" do
       method_name: :escape,
       arguments: ["foo"],
       return_value: "bar",
-      mocked_instance: TestRegexp
+      mocked_obj: TestRegexp
     )
   end
 
@@ -117,14 +134,14 @@ describe "#proxy_method_invoked" do
       receiver_class: TestHash,
       method_name: :initialize,
       arguments: [],
-      mocked_instance: TestHash
+      mocked_obj: TestHash
     )
     expect(mcalls.last).to have_attributes(
       receiver_class: TestHash,
       method_name: :[],
       arguments: ["a"],
       return_value: 10,
-      mocked_instance: hash_double
+      mocked_obj: hash_double
     )
   end
 end

--- a/spec/rspec/proxy_method_invoked_hook_spec.rb
+++ b/spec/rspec/proxy_method_invoked_hook_spec.rb
@@ -37,7 +37,8 @@ describe "#proxy_method_invoked" do
       receiver_class: TestHash,
       method_name: :key?,
       arguments: ["x"],
-      return_value: true
+      return_value: true,
+      mocked_instance: target
     )
   end
 
@@ -52,7 +53,8 @@ describe "#proxy_method_invoked" do
       receiver_class: TestHash,
       method_name: :key?,
       arguments: ["x"],
-      return_value: true
+      return_value: true,
+      mocked_instance: target
     )
   end
 
@@ -67,7 +69,8 @@ describe "#proxy_method_invoked" do
       receiver_class: Hash,
       method_name: :key?,
       arguments: ["x"],
-      return_value: true
+      return_value: true,
+      mocked_instance: target
     )
   end
 
@@ -82,7 +85,8 @@ describe "#proxy_method_invoked" do
       receiver_class: Hash,
       method_name: :key?,
       arguments: ["x"],
-      return_value: true
+      return_value: true,
+      mocked_instance: target
     )
   end
 
@@ -95,7 +99,8 @@ describe "#proxy_method_invoked" do
       receiver_class: TestRegexp.singleton_class,
       method_name: :escape,
       arguments: ["foo"],
-      return_value: "bar"
+      return_value: "bar",
+      mocked_instance: TestRegexp
     )
   end
 
@@ -111,13 +116,15 @@ describe "#proxy_method_invoked" do
     expect(mcalls.first).to have_attributes(
       receiver_class: TestHash,
       method_name: :initialize,
-      arguments: []
+      arguments: [],
+      mocked_instance: TestHash
     )
     expect(mcalls.last).to have_attributes(
       receiver_class: TestHash,
       method_name: :[],
       arguments: ["a"],
-      return_value: 10
+      return_value: 10,
+      mocked_instance: hash_double
     )
   end
 end

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -10,14 +10,15 @@ module IntegrationHelpers
     "bundle exec ruby"
   end
 
-  RSPEC_STUB = File.join(__dir__, "../../bin/rspec")
+  ROOT_DIR = File.expand_path(".")
+  RSPEC_STUB = File.join(ROOT_DIR, "bin/rspec")
 
   def run_rspec(path, chdir: nil, success: true, env: {}, options: "")
-    command = "#{RUBY_RUNNER} #{RSPEC_STUB} #{options} #{path}_fixture.rb"
+    command = "#{RUBY_RUNNER} #{RSPEC_STUB} #{options} spec/fixtures/rspec/#{path}_fixture.rb"
     output, err, status = Open3.capture3(
       env,
       command,
-      chdir: chdir || File.expand_path("../../fixtures/rspec", __FILE__)
+      chdir: ROOT_DIR
     )
 
     if ENV["DEBUG"] == "1"

--- a/spec/support/integration_helpers.rb
+++ b/spec/support/integration_helpers.rb
@@ -15,6 +15,8 @@ module IntegrationHelpers
 
   def run_rspec(path, chdir: nil, success: true, env: {}, options: "")
     command = "#{RUBY_RUNNER} #{RSPEC_STUB} #{options} spec/fixtures/rspec/#{path}_fixture.rb"
+    env = env.dup
+    env["CI"] = ENV["CI"]
     output, err, status = Open3.capture3(
       env,
       command,

--- a/spec/type_checks/sorbet_spec.rb
+++ b/spec/type_checks/sorbet_spec.rb
@@ -98,7 +98,8 @@ describe MockSuey::TypeChecks::Sorbet do
             method_name: :simple_block,
             arguments: [123],
             mocked_obj: target,
-            block: block
+            block: block,
+            return_value: "333"
           )
 
           expect(checker.typecheck!(mcall)).to eq("333")
@@ -191,7 +192,8 @@ describe MockSuey::TypeChecks::Sorbet do
             receiver_class: TaxCalculatorSorbet,
             method_name: :simple_test,
             arguments: [120],
-            mocked_obj: target
+            mocked_obj: target,
+            return_value: 333
           )
 
           expect(checker.typecheck!(mcall)).to eq(333)
@@ -252,7 +254,8 @@ describe MockSuey::TypeChecks::Sorbet do
             receiver_class: TaxCalculatorSorbet,
             method_name: :class_method_test,
             arguments: [120],
-            mocked_obj: TaxCalculatorSorbet
+            mocked_obj: TaxCalculatorSorbet,
+            return_value: 333
           )
 
           expect(checker.typecheck!(mcall)).to eq(333)

--- a/spec/type_checks/sorbet_spec.rb
+++ b/spec/type_checks/sorbet_spec.rb
@@ -53,7 +53,7 @@ describe MockSuey::TypeChecks::Sorbet do
 
         expect do
           checker.typecheck!(mcall, raise_on_missing: true)
-        end.to raise_error(MockSuey::TypeChecks::MissingSignature)
+        end.to raise_error(MockSuey::TypeChecks::MissingSignature, /.*set raise_on_missing_types to false.*/)
       end
     end
 

--- a/spec/type_checks/sorbet_spec.rb
+++ b/spec/type_checks/sorbet_spec.rb
@@ -3,6 +3,7 @@
 require "mock_suey/type_checks/sorbet"
 require_relative "../fixtures/shared/tax_calculator_sorbet"
 
+# TODO: add singleton classes checks
 describe MockSuey::TypeChecks::Sorbet do
   subject(:checker) { described_class.new }
 
@@ -14,18 +15,31 @@ describe MockSuey::TypeChecks::Sorbet do
     end
 
     describe "type check without signatures" do
-      def create_mcall(target)
+      skip "type-checks core classes" do
+        # 'sorbet-runtime' does not include signatures for stdlib classes yet
         mcall = MockSuey::MethodCall.new(
+          receiver_class: Array,
+          method_name: :take,
+          arguments: ["first"],
+          mocked_obj: []
+        )
+
+        expect do
+          checker.typecheck!(mcall)
+        end.to raise_error(TypeError, /Expected.*Integer.*got.*String.*/)
+      end
+
+      def create_mcall(target)
+        MockSuey::MethodCall.new(
           receiver_class: TaxCalculatorSorbet,
           method_name: :simple_test_no_sig,
           arguments: [120],
-          return_value: 120,
-          mocked_instance: target
+          mocked_obj: target
         )
       end
 
       it "when raise_on_missing false" do
-        allow(target).to receive(:simple_test_no_sig).and_return(120)
+        allow(target).to receive(:simple_test_no_sig).and_return(333)
         mcall = create_mcall(target)
 
         expect do
@@ -34,7 +48,7 @@ describe MockSuey::TypeChecks::Sorbet do
       end
 
       it "when raise_on_missing true" do
-        allow(target).to receive(:simple_test_no_sig).and_return(120)
+        allow(target).to receive(:simple_test_no_sig).and_return(333)
         mcall = create_mcall(target)
 
         expect do
@@ -44,70 +58,223 @@ describe MockSuey::TypeChecks::Sorbet do
     end
 
     describe "type check argument type" do
-      it "when correct" do
-        allow(target).to receive(:simple_test).and_return(120)
+      describe "for mocked instance methods" do
+        it "when correct" do
+          allow(target).to receive(:simple_test).and_return(333)
 
-        mcall = MockSuey::MethodCall.new(
-          receiver_class: TaxCalculatorSorbet,
-          method_name: :simple_test,
-          arguments: [120],
-          return_value: 120,
-          mocked_instance: target
-        )
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :simple_test,
+            arguments: [120],
+            mocked_obj: target
+          )
 
-        expect do
-          checker.typecheck!(mcall)
-        end.not_to raise_error
+          expect do
+            checker.typecheck!(mcall)
+          end.not_to raise_error
+        end
+
+        it "when incorrect" do
+          allow(target).to receive(:simple_test).and_return(333)
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :simple_test,
+            arguments: ["120"],
+            mocked_obj: target
+          )
+
+          expect do
+            checker.typecheck!(mcall)
+          end.to raise_error(TypeError, /Parameter.*val.*Expected.*Integer.*got.*String.*/)
+        end
+
+        it "when block is passed correctly" do
+          allow(target).to receive(:simple_block).and_yield("444")
+          block = proc { |_n| "333" }
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :simple_block,
+            arguments: [123],
+            mocked_obj: target,
+            block: block
+          )
+
+          expect(checker.typecheck!(mcall)).to eq("333")
+          expect { checker.typecheck!(mcall) }.not_to raise_error
+        end
+
+        it "when no block has been passed" do
+          allow(target).to receive(:simple_block).and_yield("444")
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :simple_block,
+            arguments: [123],
+            mocked_obj: target
+          )
+
+          expect { checker.typecheck!(mcall) }.to raise_error(TypeError)
+        end
       end
 
-      it "when incorrect" do
-        allow(target).to receive(:simple_test).and_return(120)
+      describe "for mocked class methods" do
+        describe "initialize" do
+          let(:target) { instance_double("AccountantSorbet") }
 
-        mcall = MockSuey::MethodCall.new(
-          receiver_class: TaxCalculatorSorbet,
-          method_name: :simple_test,
-          arguments: ["120"],
-          return_value: 120,
-          mocked_instance: target
-        )
+          it "called correctly" do
+            allow(target).to receive(:initialize)
 
-        expect do
-          checker.typecheck!(mcall)
-        end.to raise_error(TypeError, /Parameter.*val.*Expected.*Integer.*got.*String.*/)
+            mcall = MockSuey::MethodCall.new(
+              receiver_class: AccountantSorbet,
+              method_name: :initialize,
+              arguments: [{tax_calculator: TaxCalculator.new}],
+              mocked_obj: target
+            )
+
+            expect { checker.typecheck!(mcall) }.not_to raise_error
+          end
+
+          it "called incorrectly" do
+            allow(target).to receive(:initialize)
+
+            mcall = MockSuey::MethodCall.new(
+              receiver_class: AccountantSorbet,
+              method_name: :initialize,
+              arguments: [{tax_calculator: "incorrect"}],
+              mocked_obj: target
+            )
+
+            expect do
+              checker.typecheck!(mcall)
+            end.to raise_error(TypeError, /.*Parameter.*tax_calculator.*Expected.*TaxCalculator.*got.*String.*/)
+          end
+        end
+
+        it "when correct" do
+          allow(TaxCalculatorSorbet).to receive(:class_method_test).and_return(333)
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :class_method_test,
+            arguments: [120],
+            mocked_obj: TaxCalculatorSorbet
+          )
+
+          expect { checker.typecheck!(mcall) }.not_to raise_error
+        end
+
+        it "when incorrect" do
+          allow(TaxCalculatorSorbet).to receive(:class_method_test).and_return(333)
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :class_method_test,
+            arguments: ["120"],
+            mocked_obj: TaxCalculatorSorbet
+          )
+
+          expect do
+            checker.typecheck!(mcall)
+          end.to raise_error(TypeError, /Parameter.*val.*Expected.*Integer.*got.*String.*/)
+        end
       end
     end
 
     describe "type check return type" do
-      it "when correct" do
-        allow(target).to receive(:simple_test).and_return(120)
+      describe "for mocked instance methods" do
+        it "when simple type is correct" do
+          allow(target).to receive(:simple_test).and_return(333)
 
-        mcall = MockSuey::MethodCall.new(
-          receiver_class: TaxCalculatorSorbet,
-          method_name: :simple_test,
-          arguments: [120],
-          return_value: 120,
-          mocked_instance: target
-        )
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :simple_test,
+            arguments: [120],
+            mocked_obj: target
+          )
 
-        expect do
-          checker.typecheck!(mcall)
-        end.not_to raise_error
+          expect(checker.typecheck!(mcall)).to eq(333)
+          expect do
+            checker.typecheck!(mcall)
+          end.not_to raise_error
+        end
+
+        it "when simple type is incorrect" do
+          allow(target).to receive(:simple_test).and_return("incorrect")
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :simple_test,
+            arguments: [120],
+            mocked_obj: target
+          )
+
+          expect do
+            checker.typecheck!(mcall)
+          end.to raise_error(TypeError, /.*Return value.*Expected.*Integer.*got.*String.*/)
+        end
+
+        it "when custom class is incorrect" do
+          allow(target).to receive(:for_income).and_return("incorrect")
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :for_income,
+            arguments: [120],
+            mocked_obj: target
+          )
+
+          expect do
+            checker.typecheck!(mcall)
+          end.to raise_error(TypeError, /.*Return value.*Expected.*TaxCalculator::Result.*got.*String.*/)
+        end
+
+        it "when custom class is correct" do
+          allow(target).to receive(:for_income).and_return(TaxCalculator::Result.new)
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :for_income,
+            arguments: [120],
+            mocked_obj: target
+          )
+
+          expect { checker.typecheck!(mcall) }.not_to raise_error
+        end
       end
 
-      it "when incorrect" do
-        allow(target).to receive(:simple_test).and_return("incorrect")
+      describe "for mocked class methods" do
+        it "when correct" do
+          allow(TaxCalculatorSorbet).to receive(:class_method_test).and_return(333)
 
-        mcall = MockSuey::MethodCall.new(
-          receiver_class: TaxCalculatorSorbet,
-          method_name: :simple_test,
-          arguments: [120],
-          return_value: 120,
-          mocked_instance: target
-        )
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :class_method_test,
+            arguments: [120],
+            mocked_obj: TaxCalculatorSorbet
+          )
 
-        expect do
-          checker.typecheck!(mcall)
-        end.to raise_error(TypeError, /.*Return value.*Expected.*Integer.*got.*String.*/)
+          expect(checker.typecheck!(mcall)).to eq(333)
+          expect do
+            checker.typecheck!(mcall)
+          end.not_to raise_error
+        end
+
+        it "when incorrect" do
+          allow(TaxCalculatorSorbet).to receive(:class_method_test).and_return("incorrect")
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :class_method_test,
+            arguments: [120],
+            mocked_obj: TaxCalculatorSorbet
+          )
+
+          expect do
+            checker.typecheck!(mcall)
+          end.to raise_error(TypeError, /.*Return value.*Expected.*Integer.*got.*String.*/)
+        end
       end
     end
   end

--- a/spec/type_checks/sorbet_spec.rb
+++ b/spec/type_checks/sorbet_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "mock_suey/type_checks/sorbet"
+require_relative "../fixtures/shared/tax_calculator_sorbet"
+
+describe MockSuey::TypeChecks::Sorbet do
+  subject(:checker) { described_class.new }
+
+  context "with signatures" do
+    let(:target) { instance_double("TaxCalculatorSorbet") }
+
+    subject(:checker) do
+      described_class.new
+    end
+
+    describe "type check argument type" do
+      it "when correct" do
+        allow(target).to receive(:simple_test).and_return(120)
+
+        mcall = MockSuey::MethodCall.new(
+          receiver_class: TaxCalculatorSorbet,
+          method_name: :simple_test,
+          arguments: [120],
+          return_value: 120,
+          mocked_instance: target
+        )
+
+        expect do
+          checker.typecheck!(mcall)
+        end.not_to raise_error
+      end
+
+      it "when incorrect" do
+        allow(target).to receive(:simple_test).and_return(120)
+
+        mcall = MockSuey::MethodCall.new(
+          receiver_class: TaxCalculatorSorbet,
+          method_name: :simple_test,
+          arguments: ["120"],
+          return_value: 120,
+          mocked_instance: target
+        )
+
+        expect do
+          checker.typecheck!(mcall)
+        end.to raise_error(TypeError, /Parameter.*val.*Expected.*Integer.*got.*String.*/)
+      end
+    end
+
+    describe "type check return type" do
+      it "when correct" do
+        allow(target).to receive(:simple_test).and_return(120)
+
+        mcall = MockSuey::MethodCall.new(
+          receiver_class: TaxCalculatorSorbet,
+          method_name: :simple_test,
+          arguments: [120],
+          return_value: 120,
+          mocked_instance: target
+        )
+
+        expect do
+          checker.typecheck!(mcall)
+        end.not_to raise_error
+      end
+
+      it "when incorrect" do
+        allow(target).to receive(:simple_test).and_return("incorrect")
+
+        mcall = MockSuey::MethodCall.new(
+          receiver_class: TaxCalculatorSorbet,
+          method_name: :simple_test,
+          arguments: [120],
+          return_value: 120,
+          mocked_instance: target
+        )
+
+        expect do
+          checker.typecheck!(mcall)
+        end.to raise_error(TypeError, /.*Return value.*Expected.*Integer.*got.*String.*/)
+      end
+    end
+  end
+end

--- a/spec/type_checks/sorbet_spec.rb
+++ b/spec/type_checks/sorbet_spec.rb
@@ -13,6 +13,36 @@ describe MockSuey::TypeChecks::Sorbet do
       described_class.new
     end
 
+    describe "type check without signatures" do
+      def create_mcall(target)
+        mcall = MockSuey::MethodCall.new(
+          receiver_class: TaxCalculatorSorbet,
+          method_name: :simple_test_no_sig,
+          arguments: [120],
+          return_value: 120,
+          mocked_instance: target
+        )
+      end
+
+      it "when raise_on_missing false" do
+        allow(target).to receive(:simple_test_no_sig).and_return(120)
+        mcall = create_mcall(target)
+
+        expect do
+          checker.typecheck!(mcall)
+        end.not_to raise_error
+      end
+
+      it "when raise_on_missing true" do
+        allow(target).to receive(:simple_test_no_sig).and_return(120)
+        mcall = create_mcall(target)
+
+        expect do
+          checker.typecheck!(mcall, raise_on_missing: true)
+        end.to raise_error(MockSuey::TypeChecks::MissingSignature)
+      end
+    end
+
     describe "type check argument type" do
       it "when correct" do
         allow(target).to receive(:simple_test).and_return(120)

--- a/spec/type_checks/sorbet_spec.rb
+++ b/spec/type_checks/sorbet_spec.rb
@@ -286,12 +286,29 @@ describe MockSuey::TypeChecks::Sorbet do
             receiver_class: TaxCalculatorSorbet,
             method_name: :simple_test_no_runtime,
             arguments: [120],
-            mocked_obj: target
+            mocked_obj: target,
+            return_value: "incorrect"
           )
 
           expect do
             checker.typecheck!(mcall)
           end.not_to raise_error
+        end
+
+        it "raises error when added on_failure()" do
+          allow(target).to receive(:simple_test_log_on_error).and_return("incorrect")
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :simple_test_log_on_error,
+            arguments: [120],
+            mocked_obj: target,
+            return_value: "incorrect"
+          )
+
+          expect do
+            checker.typecheck!(mcall)
+          end.to raise_error(TypeError)
         end
       end
 

--- a/spec/type_checks/sorbet_spec.rb
+++ b/spec/type_checks/sorbet_spec.rb
@@ -3,7 +3,6 @@
 require "mock_suey/type_checks/sorbet"
 require_relative "../fixtures/shared/tax_calculator_sorbet"
 
-# TODO: add singleton classes checks
 describe MockSuey::TypeChecks::Sorbet do
   subject(:checker) { described_class.new }
 

--- a/spec/type_checks/sorbet_spec.rb
+++ b/spec/type_checks/sorbet_spec.rb
@@ -278,6 +278,21 @@ describe MockSuey::TypeChecks::Sorbet do
 
           expect { checker.typecheck!(mcall) }.not_to raise_error
         end
+
+        it "does not raise type error when without runtime" do
+          allow(target).to receive(:simple_test_no_runtime).and_return("incorrect")
+
+          mcall = MockSuey::MethodCall.new(
+            receiver_class: TaxCalculatorSorbet,
+            method_name: :simple_test_no_runtime,
+            arguments: [120],
+            mocked_obj: target
+          )
+
+          expect do
+            checker.typecheck!(mcall)
+          end.not_to raise_error
+        end
       end
 
       describe "for mocked class methods" do


### PR DESCRIPTION
# Implementation proposal

## Initial setup details

1. Add `sorbet` to `TYPE_CHECKERS` in `core.rb`
2. Use `lib/type_check/ruby.rb` as a template for the new checker `lib/type_check/sorbet.rb` (and tests too)

## Sorbet library integration details

### Option 1: Use Sorbet methods inside `typecheck!`

1. Find the original method's signature (see below)
3. Use [`validate_call`](https://github.com/sorbet/sorbet/blob/master/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb#L181) and related methods inside `typecheck!`

### Looking for the signature of the original method

```ruby
T::Private::Methods.signature_for_method(ReceiverClassName.instance_method :method_name)
```

### Typecheck 2: CallValidation

It is possible to check types of incoming arguments, which I am also going to implement using `CallValidation`

## Useful Mock Suey methods

I include methods from Mock Suey that might be used during this feature development, or at least their understanding is necessary for me to write the code. They also might be helpful during code review.

```
Rspec before
  MockSuey.cook
    setup_type_checker
    signature_load_dirs
    on_mocked_call: adds type_checker.typecheck! lambda to array @on_mocked_callbacks

Rspec after
    MockSuey.eat # Probably nothing to see in here for now

Rspec::MethodDouble.prepend
    ProxyMethodInvokedHook # wraps mock method and setups type checking
      MockSuey.handle_method_call

MockSuey.handle_method_call(call_obj: MockSuey::MethodCall)
    lazy init type_checker
      load_dirs # Might cause problems, need to research how to work with sorbet

type_checker.typecheck!
```

## Useful Sorbet methods

I am going to use [sorbet-runtime](https://github.com/sorbet/sorbet/tree/master/gems/sorbet-runtime) as it includes signatures and typechecker.

[`sig` method](https://github.com/sorbet/sorbet/blob/master/gems/sorbet-runtime/lib/types/sig.rb#L27)

[module `Methods`](https://github.com/sorbet/sorbet/blob/master/gems/sorbet-runtime/lib/types/private/methods/_methods.rb) which contains the most important source code for me.

```
sig.rb:
  sig method

T::Private::Methods:
	declare_sig
	install_hooks on the class or module to extend with MethodHooks, SingletonMethodHooks
	reset! current declaration after installing the hooks
	set active_declaration (DeclarationBlock class)
	
	method_added
	_on_method_added
		sig_block
		replace method with a wrapper
		add method to @sig_wrappers using key

      CallValidation.validate_call
```


**Other useful things:**

[caller_location](https://jemma.dev/blog/enumerable-tally)

[sorbet configuration](https://sorbet.org/docs/tconfiguration)

[method_added](https://apidock.com/ruby/Module/method_added)